### PR TITLE
Add a very basic support for multi-server handling.

### DIFF
--- a/src/action/start.rs
+++ b/src/action/start.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
 
 use clap::ArgMatches;
 
@@ -15,9 +13,6 @@ const RCON_PASSWORD_LENGTH: usize = 32;
 
 /// Start lazymc.
 pub fn invoke(matches: &ArgMatches) -> Result<(), ()> {
-    // Parse bind address
-    let bind_addr: SocketAddr = matches.get_one::<String>("bind").unwrap().parse().unwrap();
-
     // Load config
     #[allow(unused_mut)]
     let mut configs = config::load(matches);
@@ -32,8 +27,7 @@ pub fn invoke(matches: &ArgMatches) -> Result<(), ()> {
     }
 
     // Start server service
-    let configs_arc = configs.into_iter().map(Arc::new).collect();
-    service::server::service(bind_addr, configs_arc)
+    service::server::service(configs)
 }
 
 /// Prepare RCON.

--- a/src/action/start.rs
+++ b/src/action/start.rs
@@ -28,11 +28,11 @@ pub fn invoke(matches: &ArgMatches) -> Result<(), ()> {
         prepare_rcon(config);
 
         // Rewrite server server.properties file
-        rewrite_server_properties(&config);
+        rewrite_server_properties(config);
     }
 
     // Start server service
-    let configs_arc = configs.into_iter().map(|config| Arc::new(config)).collect();
+    let configs_arc = configs.into_iter().map(Arc::new).collect();
     service::server::service(bind_addr, configs_arc)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,14 +25,6 @@ pub fn app() -> Command {
                 .subcommand(Command::new("test").about("Test config")),
         )
         .arg(
-            Arg::new("bind")
-                .short('b')
-                .value_name("ADDRESS")
-                .default_value("0.0.0.0:25565")
-                .help("Address to bind to")
-                .num_args(1),
-        )
-        .arg(
             Arg::new("config")
                 .short('c')
                 .alias("cfg")

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ pub fn load(matches: &ArgMatches) -> Vec<Config> {
     };
 
     // Ensure configuration file/directory exists
-    if paths.len() == 0 {
+    if paths.is_empty() {
         quit_error_msg(
             format!(
                 "Config file/directory does not exist: {}",
@@ -59,7 +59,7 @@ pub fn load(matches: &ArgMatches) -> Vec<Config> {
         );
     }
 
-    paths.into_iter().map(|path| load_file(path)).collect()
+    paths.into_iter().map(load_file).collect()
 }
 
 /// Load config from file, based on CLI arguments.

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,12 +28,17 @@ pub fn load(matches: &ArgMatches) -> Vec<Config> {
         path.read_dir()
             .unwrap()
             .filter_map(|entry| entry.ok())
-            .map(|entry| entry.path()).collect()
+            .map(|entry| entry.path())
+            .collect()
     } else {
         vec![path.clone()]
     };
 
-    let configs: Vec<Config> = paths.into_iter().filter(|path| path.is_file()).map(load_file).collect();
+    let configs: Vec<Config> = paths
+        .into_iter()
+        .filter(|path| path.is_file())
+        .map(load_file)
+        .collect();
 
     // Ensure configuration file/directory exists
     if configs.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,8 +155,10 @@ impl Config {
 #[serde(default)]
 pub struct Public {
     /// Public address.
-    // #[serde(deserialize_with = "to_socket_addrs")]
-    pub address: String, // SocketAddr,
+    ///
+    /// The address lazymc will bind to and listen for incoming connections.
+    #[serde(deserialize_with = "to_socket_addrs")]
+    pub address: SocketAddr,
 
     /// Minecraft protocol version name hint.
     pub version: String,
@@ -186,6 +188,12 @@ pub struct Server {
 
     /// Start command.
     pub command: String,
+
+    /// Server Name.
+    ///
+    /// Incoming connections will be routed to this server according to the name in the handshake packet.
+    /// If no name is provided this server will act as a "catch-all" and be routed all connections where no other names match.
+    pub name: Option<String>,
 
     /// Server address.
     #[serde(

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,25 +27,16 @@ pub fn load(matches: &ArgMatches) -> Vec<Config> {
     let paths: Vec<PathBuf> = if path.is_dir() {
         path.read_dir()
             .unwrap()
-            .filter_map(|entry| {
-                entry.ok().and_then(|entry| {
-                    let path = entry.path();
-                    if path.is_file() {
-                        Some(path)
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect()
-    } else if path.is_file() {
-        vec![path.clone()]
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path()).collect()
     } else {
-        vec![]
+        vec![path.clone()]
     };
 
+    let configs: Vec<Config> = paths.into_iter().filter(|path| path.is_file()).map(load_file).collect();
+
     // Ensure configuration file/directory exists
-    if paths.is_empty() {
+    if configs.is_empty() {
         quit_error_msg(
             format!(
                 "Config file/directory does not exist: {}",
@@ -59,7 +50,7 @@ pub fn load(matches: &ArgMatches) -> Vec<Config> {
         );
     }
 
-    paths.into_iter().map(load_file).collect()
+    configs
 }
 
 /// Load config from file, based on CLI arguments.

--- a/src/join/forward.rs
+++ b/src/join/forward.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use bytes::BytesMut;
 use tokio::net::TcpStream;
 
@@ -11,7 +9,7 @@ use super::MethodResult;
 
 /// Forward the client.
 pub async fn occupy(
-    config: Arc<Config>,
+    config: &Config,
     inbound: TcpStream,
     inbound_history: &mut BytesMut,
 ) -> Result<MethodResult, ()> {

--- a/src/join/kick.rs
+++ b/src/join/kick.rs
@@ -1,6 +1,5 @@
 use tokio::net::TcpStream;
 
-use crate::config::*;
 use crate::net;
 use crate::proto::action;
 use crate::proto::client::Client;
@@ -11,7 +10,6 @@ use super::MethodResult;
 /// Kick the client.
 pub async fn occupy(
     client: &Client,
-    config: &Config,
     server: &Server,
     mut inbound: TcpStream,
 ) -> Result<MethodResult, ()> {
@@ -20,9 +18,9 @@ pub async fn occupy(
     // Select message and kick
     let msg = match server.state() {
         server::State::Starting | server::State::Stopped | server::State::Started => {
-            &config.join.kick.starting
+            &server.config.join.kick.starting
         }
-        server::State::Stopping => &config.join.kick.stopping,
+        server::State::Stopping => &server.config.join.kick.stopping,
     };
     action::kick(client, msg, &mut inbound.split().1).await?;
 

--- a/src/join/lobby.rs
+++ b/src/join/lobby.rs
@@ -14,7 +14,6 @@ use super::MethodResult;
 pub async fn occupy(
     client: &Client,
     client_info: ClientInfo,
-    config: Arc<Config>,
     server: Arc<Server>,
     inbound: TcpStream,
     inbound_queue: BytesMut,
@@ -22,13 +21,13 @@ pub async fn occupy(
     trace!(target: "lazymc", "Using lobby method to occupy joining client");
 
     // Must be ready to lobby
-    if must_still_probe(&config, &server).await {
+    if must_still_probe(&server.config, &server).await {
         warn!(target: "lazymc", "Client connected but lobby is not ready, using next join method, probing not completed");
         return Ok(MethodResult::Continue(inbound));
     }
 
     // Start lobby
-    lobby::serve(client, client_info, inbound, config, server, inbound_queue).await?;
+    lobby::serve(client, client_info, inbound, server, inbound_queue).await?;
 
     // TODO: do not consume client here, allow other join method on fail
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ pub(crate) mod os;
 pub(crate) mod probe;
 pub(crate) mod proto;
 pub(crate) mod proxy;
+pub(crate) mod router;
 pub(crate) mod server;
 pub(crate) mod service;
 pub(crate) mod status;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -75,10 +75,7 @@ pub async fn monitor_server(server: Arc<Server>) {
 ///
 /// Returns `Ok` if status/ping succeeded, includes server status most of the time.
 /// Returns `Err` if no connection could be established or if an error occurred.
-pub async fn poll_server(
-    server: &Server,
-    addr: SocketAddr,
-) -> Result<Option<ServerStatus>, ()> {
+pub async fn poll_server(server: &Server, addr: SocketAddr) -> Result<Option<ServerStatus>, ()> {
     // Fetch status
     if let Ok(status) = fetch_status(&server.config, addr).await {
         return Ok(Some(status));

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -30,9 +30,9 @@ const STATUS_TIMEOUT: u64 = 20;
 const PING_TIMEOUT: u64 = 10;
 
 /// Monitor server.
-pub async fn monitor_server(config: Arc<Config>, server: Arc<Server>) {
+pub async fn monitor_server(server: Arc<Server>) {
     // Server address
-    let addr = config.server.address;
+    let addr = server.config.server.address;
 
     let mut poll_interval = time::interval(MONITOR_POLL_INTERVAL);
 
@@ -41,13 +41,13 @@ pub async fn monitor_server(config: Arc<Config>, server: Arc<Server>) {
 
         // Poll server state and update internal status
         trace!(target: "lazymc::monitor", "Fetching status for {} ... ", addr);
-        let status = poll_server(&config, &server, addr).await;
+        let status = poll_server(&server, addr).await;
         match status {
             // Got status, update
-            Ok(Some(status)) => server.update_status(&config, Some(status)).await,
+            Ok(Some(status)) => server.update_status(Some(status)).await,
 
             // Error, reset status
-            Err(_) => server.update_status(&config, None).await,
+            Err(_) => server.update_status(None).await,
 
             // Didn't get status, but ping fallback worked, leave as-is, show warning
             Ok(None) => {
@@ -56,9 +56,9 @@ pub async fn monitor_server(config: Arc<Config>, server: Arc<Server>) {
         }
 
         // Sleep server when it's bedtime
-        if server.should_sleep(&config).await {
+        if server.should_sleep(&server.config).await {
             info!(target: "lazymc::montior", "Server has been idle, sleeping...");
-            server.stop(&config).await;
+            server.stop().await;
         }
 
         // Check whether we should force kill server
@@ -76,19 +76,18 @@ pub async fn monitor_server(config: Arc<Config>, server: Arc<Server>) {
 /// Returns `Ok` if status/ping succeeded, includes server status most of the time.
 /// Returns `Err` if no connection could be established or if an error occurred.
 pub async fn poll_server(
-    config: &Config,
     server: &Server,
     addr: SocketAddr,
 ) -> Result<Option<ServerStatus>, ()> {
     // Fetch status
-    if let Ok(status) = fetch_status(config, addr).await {
+    if let Ok(status) = fetch_status(&server.config, addr).await {
         return Ok(Some(status));
     }
 
     // Try ping fallback if server is currently started
     if server.state() == State::Started {
         debug!(target: "lazymc::monitor", "Failed to get status from started server, trying ping...");
-        do_ping(config, addr).await?;
+        do_ping(&server.config, addr).await?;
     }
 
     Err(())

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,17 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::server::Server;
+
+#[derive(Default)]
+pub struct Router {
+    pub data: HashMap<Option<String>, Arc<Server>>,
+}
+
+impl Router {
+    pub fn get(&self, server_name: String) -> Option<Arc<Server>> {
+        self.data
+            .get(&Some(server_name))
+            .or_else(|| self.data.get(&None))
+            .cloned()
+    }
+}

--- a/src/service/file_watcher.rs
+++ b/src/service/file_watcher.rs
@@ -14,9 +14,9 @@ use crate::server::Server;
 const WATCH_DEBOUNCE: Duration = Duration::from_secs(2);
 
 /// Service to watch server file changes.
-pub fn service(config: Arc<Config>, server: Arc<Server>) {
+pub fn service(server: Arc<Server>) {
     // Ensure server directory is set, it must exist
-    let dir = match ConfigServer::server_directory(&config) {
+    let dir = match ConfigServer::server_directory(&server.config) {
         Some(dir) if dir.is_dir() => dir,
         _ => {
             warn!(target: "lazymc", "Server directory doesn't exist, can't watch file changes to reload whitelist and banned IPs");
@@ -28,11 +28,11 @@ pub fn service(config: Arc<Config>, server: Arc<Server>) {
     #[allow(clippy::blocks_in_if_conditions)]
     while {
         // Update all files once
-        reload_bans(&config, &server, &dir.join(ban::FILE));
-        reload_whitelist(&config, &server, &dir);
+        reload_bans(&server.config, &server, &dir.join(ban::FILE));
+        reload_whitelist(&server.config, &server, &dir);
 
         // Watch for changes, update accordingly
-        watch_server(&config, &server, &dir)
+        watch_server(&server.config, &server, &dir)
     } {}
 }
 

--- a/src/service/monitor.rs
+++ b/src/service/monitor.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use crate::config::Config;
 use crate::monitor;
 use crate::server::Server;
 
 /// Server monitor task.
-pub async fn service(config: Arc<Config>, state: Arc<Server>) {
-    monitor::monitor_server(config, state).await
+pub async fn service(server: Arc<Server>) {
+    monitor::monitor_server(server).await
 }

--- a/src/service/probe.rs
+++ b/src/service/probe.rs
@@ -5,14 +5,14 @@ use crate::probe;
 use crate::server::Server;
 
 /// Probe server.
-pub async fn service(config: Arc<Config>, state: Arc<Server>) {
+pub async fn service(server: Arc<Server>) {
     // Only probe if enabled or if we must
-    if !config.server.probe_on_start && !must_probe(&config) {
+    if !server.config.server.probe_on_start && !must_probe(&server.config) {
         return;
     }
 
     // Probe
-    match probe::probe(config, state).await {
+    match probe::probe(server).await {
         Ok(_) => info!(target: "lazymc::probe", "Succesfully probed server"),
         Err(_) => {
             error!(target: "lazymc::probe", "Failed to probe server, this may limit lazymc features")

--- a/src/service/signal.rs
+++ b/src/service/signal.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use crate::config::Config;
 use crate::server::{self, Server};
 use crate::util::error;
 
 /// Signal handler task.
-pub async fn service(config: Arc<Config>, server: Arc<Server>) {
+pub async fn service(server: Arc<Server>) {
     loop {
         // Wait for SIGTERM/SIGINT signal
         tokio::signal::ctrl_c().await.unwrap();
@@ -16,7 +15,7 @@ pub async fn service(config: Arc<Config>, server: Arc<Server>) {
         }
 
         // Try to stop server
-        let stopping = server.stop(&config).await;
+        let stopping = server.stop().await;
 
         // If not stopping, maybe due to failure, just quit
         if !stopping {

--- a/src/status.rs
+++ b/src/status.rs
@@ -5,7 +5,6 @@ use minecraft_protocol::data::chat::{Message, Payload};
 use minecraft_protocol::data::server_status::*;
 use minecraft_protocol::decoder::Decoder;
 use minecraft_protocol::encoder::Encoder;
-use minecraft_protocol::version::v1_14_4::handshake::Handshake;
 use minecraft_protocol::version::v1_14_4::login::LoginStart;
 use minecraft_protocol::version::v1_14_4::status::StatusResponse;
 use tokio::fs;
@@ -19,9 +18,7 @@ use crate::proto::action;
 use crate::proto::client::{Client, ClientInfo, ClientState};
 use crate::proto::packet::{self, RawPacket};
 use crate::proto::packets;
-use crate::router::Router;
-use crate::server::{self, Server, State};
-use crate::service::server::route_proxy_queue;
+use crate::server::{self, Server};
 
 /// The ban message prefix.
 const BAN_MESSAGE_PREFIX: &str = "Your IP address is banned from this server.\nReason: ";
@@ -37,30 +34,19 @@ const SERVER_ICON_FILE: &str = "server-icon.png";
 
 /// Proxy the given inbound stream to a target address.
 // TODO: do not drop error here, return Box<dyn Error>
-pub async fn serve(client: Client, mut inbound: TcpStream, router: Arc<Router>) -> Result<(), ()> {
+pub async fn serve(
+    client: Client,
+    mut inbound: TcpStream,
+    server: Arc<Server>,
+    mut inbound_history: BytesMut,
+    mut client_info: ClientInfo,
+) -> Result<(), ()> {
     let (mut reader, mut writer) = inbound.split();
 
     // Incoming buffer and packet holding queue
     let mut buf = BytesMut::new();
 
-    // Remember inbound packets, track client info
-    let mut inbound_history = BytesMut::new();
-    let mut client_info = ClientInfo::empty();
-
     loop {
-        let server = client_info
-            .handshake
-            .as_ref()
-            .and_then(|handshake| router.get(handshake.server_addr.clone()));
-
-        if let Some(server) = server
-            .clone()
-            .filter(|server| server.state() == State::Started)
-        {
-            route_proxy_queue(inbound, &server.config, inbound_history);
-            return Ok(());
-        }
-
         // Read packet from stream
         let (packet, raw) = match packet::read_packet(&client, &mut buf, &mut reader).await {
             Ok(Some(packet)) => packet,
@@ -74,140 +60,100 @@ pub async fn serve(client: Client, mut inbound: TcpStream, router: Arc<Router>) 
         // Grab client state
         let client_state = client.state();
 
-        // Hijack handshake
-        if client_state == ClientState::Handshake
-            && packet.id == packets::handshake::SERVER_HANDSHAKE
-        {
-            // Parse handshake
-            let handshake = match Handshake::decode(&mut packet.data.as_slice()) {
-                Ok(handshake) => handshake,
-                Err(_) => {
-                    debug!(target: "lazymc", "Got malformed handshake from client, disconnecting");
-                    break;
-                }
-            };
-
-            // Parse new state
-            let new_state = match ClientState::from_id(handshake.next_state) {
-                Some(state) => state,
-                None => {
-                    error!(target: "lazymc", "Client tried to switch into unknown protcol state ({}), disconnecting", handshake.next_state);
-                    break;
-                }
-            };
-
-            // Update client info and client state
-            client_info
-                .protocol
-                .replace(handshake.protocol_version as u32);
-            client_info.handshake.replace(handshake);
-            client.set_state(new_state);
-
-            // If loggin in with handshake, remember inbound
-            if new_state == ClientState::Login {
-                inbound_history.extend(raw);
-            }
-
-            continue;
-        }
-
         // Hijack ping packet
         if client_state == ClientState::Status && packet.id == packets::status::SERVER_PING {
             writer.write_all(&raw).await.map_err(|_| ())?;
             continue;
         }
 
-        if let Some(server) = server {
-            // Hijack server status packet
-            if client_state == ClientState::Status && packet.id == packets::status::SERVER_STATUS {
-                let server_status = server_status(&client_info, &server).await;
-                let packet = StatusResponse { server_status };
+        // Hijack server status packet
+        if client_state == ClientState::Status && packet.id == packets::status::SERVER_STATUS {
+            let server_status = server_status(&client_info, &server).await;
+            let packet = StatusResponse { server_status };
 
-                let mut data = Vec::new();
-                packet.encode(&mut data).map_err(|_| ())?;
+            let mut data = Vec::new();
+            packet.encode(&mut data).map_err(|_| ())?;
 
-                let response = RawPacket::new(0, data).encode_with_len(&client)?;
-                writer.write_all(&response).await.map_err(|_| ())?;
+            let response = RawPacket::new(0, data).encode_with_len(&client)?;
+            writer.write_all(&response).await.map_err(|_| ())?;
 
-                continue;
+            continue;
+        }
+
+        // Hijack login start
+        if client_state == ClientState::Login && packet.id == packets::login::SERVER_LOGIN_START {
+            // Try to get login username, update client info
+            // TODO: we should always parse this packet successfully
+            let username = LoginStart::decode(&mut packet.data.as_slice())
+                .ok()
+                .map(|p| p.name);
+            client_info.username = username.clone();
+
+            // Kick if lockout is enabled
+            if server.config.lockout.enabled {
+                match username {
+                    Some(username) => {
+                        info!(target: "lazymc", "Kicked '{}' because lockout is enabled", username)
+                    }
+                    None => {
+                        info!(target: "lazymc", "Kicked player because lockout is enabled")
+                    }
+                }
+                action::kick(&client, &server.config.lockout.message, &mut writer).await?;
+                break;
             }
 
-            // Hijack login start
-            if client_state == ClientState::Login && packet.id == packets::login::SERVER_LOGIN_START
-            {
-                // Try to get login username, update client info
-                // TODO: we should always parse this packet successfully
-                let username = LoginStart::decode(&mut packet.data.as_slice())
-                    .ok()
-                    .map(|p| p.name);
-                client_info.username = username.clone();
-
-                // Kick if lockout is enabled
-                if server.config.lockout.enabled {
-                    match username {
-                        Some(username) => {
-                            info!(target: "lazymc", "Kicked '{}' because lockout is enabled", username)
-                        }
-                        None => {
-                            info!(target: "lazymc", "Kicked player because lockout is enabled")
-                        }
-                    }
-                    action::kick(&client, &server.config.lockout.message, &mut writer).await?;
+            // Kick if client is banned
+            if let Some(ban) = server.ban_entry(&client.peer.ip()).await {
+                if ban.is_banned() {
+                    let msg = if let Some(reason) = ban.reason {
+                        info!(target: "lazymc", "Login from banned IP {} ({}), disconnecting", client.peer.ip(), &reason);
+                        reason.to_string()
+                    } else {
+                        info!(target: "lazymc", "Login from banned IP {}, disconnecting", client.peer.ip());
+                        DEFAULT_BAN_REASON.to_string()
+                    };
+                    action::kick(&client, &format!("{BAN_MESSAGE_PREFIX}{msg}"), &mut writer)
+                        .await?;
                     break;
                 }
-
-                // Kick if client is banned
-                if let Some(ban) = server.ban_entry(&client.peer.ip()).await {
-                    if ban.is_banned() {
-                        let msg = if let Some(reason) = ban.reason {
-                            info!(target: "lazymc", "Login from banned IP {} ({}), disconnecting", client.peer.ip(), &reason);
-                            reason.to_string()
-                        } else {
-                            info!(target: "lazymc", "Login from banned IP {}, disconnecting", client.peer.ip());
-                            DEFAULT_BAN_REASON.to_string()
-                        };
-                        action::kick(&client, &format!("{BAN_MESSAGE_PREFIX}{msg}"), &mut writer)
-                            .await?;
-                        break;
-                    }
-                }
-
-                // Kick if client is not whitelisted to wake server
-                if let Some(ref username) = username {
-                    if !server.is_whitelisted(username).await {
-                        info!(target: "lazymc", "User '{}' tried to wake server but is not whitelisted, disconnecting", username);
-                        action::kick(&client, WHITELIST_MESSAGE, &mut writer).await?;
-                        break;
-                    }
-                }
-
-                // Start server if not starting yet
-                Server::start(server.clone(), username).await;
-
-                // Remember inbound packets
-                inbound_history.extend(&raw);
-                inbound_history.extend(&buf);
-
-                // Build inbound packet queue with everything from login start (including this)
-                let mut login_queue = BytesMut::with_capacity(raw.len() + buf.len());
-                login_queue.extend(&raw);
-                login_queue.extend(&buf);
-
-                // Buf is fully consumed here
-                buf.clear();
-
-                // Start occupying client
-                join::occupy(
-                    client,
-                    client_info,
-                    server.clone(),
-                    inbound,
-                    inbound_history,
-                    login_queue,
-                )
-                .await?;
-                return Ok(());
             }
+
+            // Kick if client is not whitelisted to wake server
+            if let Some(ref username) = username {
+                if !server.is_whitelisted(username).await {
+                    info!(target: "lazymc", "User '{}' tried to wake server but is not whitelisted, disconnecting", username);
+                    action::kick(&client, WHITELIST_MESSAGE, &mut writer).await?;
+                    break;
+                }
+            }
+
+            // Start server if not starting yet
+            Server::start(server.clone(), username).await;
+
+            // Remember inbound packets
+            inbound_history.extend(&raw);
+            inbound_history.extend(&buf);
+
+            // Build inbound packet queue with everything from login start (including this)
+            let mut login_queue = BytesMut::with_capacity(raw.len() + buf.len());
+            login_queue.extend(&raw);
+            login_queue.extend(&buf);
+
+            // Buf is fully consumed here
+            buf.clear();
+
+            // Start occupying client
+            join::occupy(
+                client,
+                client_info,
+                server.clone(),
+                inbound,
+                inbound_history,
+                login_queue,
+            )
+            .await?;
+            return Ok(());
         }
 
         // Show unhandled packet warning

--- a/src/status.rs
+++ b/src/status.rs
@@ -114,7 +114,7 @@ pub async fn serve(
                 if client_state == ClientState::Status
                     && packet.id == packets::status::SERVER_STATUS
                 {
-                    let server_status = server_status(&client_info, &config, &server).await;
+                    let server_status = server_status(&client_info, config, server).await;
                     let packet = StatusResponse { server_status };
 
                     let mut data = Vec::new();


### PR DESCRIPTION
I have tried fixing #40 myself as a bit of a challenge to learn Rust. This is my first time touching Rust so the code quality is probably terrible, I am having tons of trouble understanding references, Arc, Mutex and RwLocks, and the borrow checker in general.

However, I have manage to create a very rough proof-of-concept that seems to work somewhat.

What has changed:
* cli now supports additional argument `--bind` (`127.0.0.1:25565` by default) that outlines the global bind for TCPListener
* cli argument `--config` now can point to either a single config file (`lazymc.toml` by default) or a whole directory including multiple config files
* BREAKING: `[public] address` in server config is no longer the address TCPListener binds to, now it describes the `server_address` part of the handshake pattern, by which a server is selected
* (terribly) reworked the routing to start the handshake before a server is decided and then decide and proxy the server based on the handshake

Here's an example of how to make it work
```
#/config/serverA.toml
[public]
address="server-a.example.com"
...

#/config/serverB.toml
[public]
address="server-b.example.com"
...
```
```
lazymc --config /config
```
Allows users to join either serverA or serverB via the same port depending on how it is described in their settings.

TODO:
* feat: Add ability to support multiple different addresses for each server.
* feat: More graceful 
* bug: After starting the server, it's status packets are not proxied correctly, it shows "Can't connect to server" even though connecting fully works.
