### PR TITLE
Added third party implementation for docker proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ A list of third-party implementations, projects using lazymc, that you might
 find useful:
 
 - Docker: [crbanman/papermc-lazymc](https://hub.docker.com/r/crbanman/papermc-lazymc) _(PaperMC with lazymc in Docker)_
-- Docker Proxy: [joesturge/docker-minecraft-server](https://github.com/joesturge/docker-minecraft-server) _(Works with (itzg/docker-minecraft-server)[https://github.com/itzg/docker-minecraft-server])_
+- Docker Proxy: [joesturge/docker-minecraft-server](https://github.com/joesturge/docker-minecraft-server) _(Works with [itzg/docker-minecraft-server](https://github.com/itzg/docker-minecraft-server))_
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A list of third-party implementations, projects using lazymc, that you might
 find useful:
 
 - Docker: [crbanman/papermc-lazymc](https://hub.docker.com/r/crbanman/papermc-lazymc) _(PaperMC with lazymc in Docker)_
+- Docker Proxy: [joesturge/docker-minecraft-server](https://github.com/joesturge/docker-minecraft-server) _(Works with (itzg/docker-minecraft-server)[https://github.com/itzg/docker-minecraft-server])_
 
 ## License
 


### PR DESCRIPTION
I have created a docker container which wraps LazyMc add adds the functionality to control a minecraft container

I have updated the docs to add this as an example. Feel free to check out the project here: https://github.com/joesturge/lazymc-docker-proxy

![image](https://github.com/user-attachments/assets/ef0e0524-caa0-48dc-b0d4-d6e33f578742)
