### PR TITLE
Added stdin command handling for lazymc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ tokio = { version = "1", default-features = false, features = [
     "signal",
     "sync",
     "fs",
+    "io-std",
 ] }
 toml = "0.8"
 version-compare = "0.2"

--- a/src/server.rs
+++ b/src/server.rs
@@ -408,7 +408,7 @@ impl Server {
         let mut stdin = self.stdin.lock().await;
         // Check if stdin is available and send the command
         if let Some(ref mut stdin_handle) = *stdin {
-            stdin_handle.write_all(command.as_bytes()).await?;
+            stdin_handle.write_all(format!("{}\n", command).as_bytes()).await?;
             Ok(())
         } else {
             Err("Server stdin handle is not available".into())

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,3 +3,4 @@ pub mod monitor;
 pub mod probe;
 pub mod server;
 pub mod signal;
+pub mod stdin;

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -67,6 +67,9 @@ pub async fn service(config: Arc<Config>) -> Result<(), ()> {
         route(inbound, config.clone(), server.clone());
     }
 
+    // Spawn service to redirect stdin to server
+    tokio::spawn(service::stdin::service(config.clone(), server.clone()));
+
     Ok(())
 }
 

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -62,13 +62,14 @@ pub async fn service(config: Arc<Config>) -> Result<(), ()> {
         || service::file_watcher::service(config, server)
     });
 
+    // Spawn service to redirect stdin to server
+    tokio::spawn(service::stdin::service(config.clone(), server.clone()));
+    
     // Route all incomming connections
     while let Ok((inbound, _)) = listener.accept().await {
         route(inbound, config.clone(), server.clone());
     }
 
-    // Spawn service to redirect stdin to server
-    tokio::spawn(service::stdin::service(config.clone(), server.clone()));
 
     Ok(())
 }

--- a/src/service/signal.rs
+++ b/src/service/signal.rs
@@ -1,31 +1,38 @@
 use std::sync::Arc;
+use tokio::signal;
 
 use crate::config::Config;
 use crate::server::{self, Server};
 use crate::util::error;
 
-/// Signal handler task.
+/// Main signal handler task.
 pub async fn service(config: Arc<Config>, server: Arc<Server>) {
     loop {
         // Wait for SIGTERM/SIGINT signal
-        tokio::signal::ctrl_c().await.unwrap();
-
-        // Quit if stopped
-        if server.state() == server::State::Stopped {
-            quit();
-        }
-
-        // Try to stop server
-        let stopping = server.stop(&config).await;
-
-        // If not stopping, maybe due to failure, just quit
-        if !stopping {
-            quit();
-        }
+        signal::ctrl_c().await.unwrap();
+        
+        // Call the shutdown function
+        shutdown(&config, &server).await;
     }
 }
 
-/// Gracefully quit.
+/// Shutdown the server gracefully, can be called from other modules.
+pub async fn shutdown(config: &Arc<Config>, server: &Arc<Server>) {
+    // Quit immediately if the server is already stopped
+    if server.state() == server::State::Stopped {
+        quit();
+    }
+
+    // Try to stop the server gracefully
+    let stopping = server.stop(config).await;
+
+    // If stopping fails, quit immediately
+    if !stopping {
+        quit();
+    }
+}
+
+/// Gracefully quit the application.
 fn quit() -> ! {
     // TODO: gracefully quit self
     error::quit();

--- a/src/service/stdin.rs
+++ b/src/service/stdin.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::server::Server;
 use crate::service::signal::shutdown;
 
-/// Service to read terminal input and send it to the server via RCON or signal handling.
+/// Service to read terminal input and send it to the server via piped stdin or RCON handling.
 pub async fn service(config: Arc<Config>, server: Arc<Server>) {
     // Use `tokio::io::stdin` for asynchronous standard input handling
     let stdin = io::stdin();
@@ -16,28 +16,33 @@ pub async fn service(config: Arc<Config>, server: Arc<Server>) {
             continue;
         }
 
-        // Check for quit command
-        if trimmed_line.eq_ignore_ascii_case("!quit") || trimmed_line.eq_ignore_ascii_case("!exit") {
-            info!("Received quit command");
-            // Gracefully shutdown
-            shutdown(&config, &server).await;
-            break;
-        }
+        match trimmed_line.to_ascii_lowercase().as_str() {
+            // Quit command
+            "!quit" | "!exit" => {
+                info!("Received quit command");
+                shutdown(&config, &server).await;
+                break;
+            }
 
-        // If !start command, start the server
-        if trimmed_line.eq_ignore_ascii_case("!start") {
-            info!("Received start command");
-            Server::start(config.clone(), server.clone(), None).await;
-            continue;
-        }
+            // Start the server
+            "!start" => {
+                info!("Received start command");
+                Server::start(config.clone(), server.clone(), None).await;
+            }
 
-        // If !stop command, stop the server
-        if trimmed_line.eq_ignore_ascii_case("!stop") {
-            info!("Received stop command");
-            server.stop(&config).await;
-            continue;
+            // Stop the server
+            "!stop" => {
+                info!("Received stop command");
+                server.stop(&config).await;
+            }
+
+            // Any other command is sent to the Minecraft server's stdin
+            command => {
+                info!("Sending command to Minecraft server: {}", command);
+                if let Err(e) = server.send_command(command).await {
+                    eprintln!("Failed to send command to server: {}", e);
+                }
+            }
         }
-        
     }
 }
-

--- a/src/service/stdin.rs
+++ b/src/service/stdin.rs
@@ -3,6 +3,7 @@ use tokio::io::{self, AsyncBufReadExt, BufReader};
 use crate::config::Config;
 use crate::server::Server;
 use crate::service::signal::shutdown;
+use crate::util::error;
 
 /// Service to read terminal input and send it to the server via piped stdin or RCON handling.
 pub async fn service(config: Arc<Config>, server: Arc<Server>) {
@@ -21,7 +22,7 @@ pub async fn service(config: Arc<Config>, server: Arc<Server>) {
             "!quit" | "!exit" => {
                 info!("Received quit command");
                 shutdown(&config, &server).await;
-                break;
+                error::quit();
             }
 
             // Start the server
@@ -38,7 +39,6 @@ pub async fn service(config: Arc<Config>, server: Arc<Server>) {
 
             // Any other command is sent to the Minecraft server's stdin
             command => {
-                info!("Sending command to Minecraft server: {}", command);
                 if let Err(e) = server.send_command(command).await {
                     eprintln!("Failed to send command to server: {}", e);
                 }

--- a/src/service/stdin.rs
+++ b/src/service/stdin.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+use tokio::io::{self, AsyncBufReadExt, BufReader};
+use crate::config::Config;
+use crate::server::Server;
+
+#[cfg(feature = "rcon")]
+use crate::mc::rcon::Rcon;
+
+/// Service to read terminal input and send it to the server via RCON or signal handling.
+pub async fn service(config: Arc<Config>, _server: Arc<Server>) {
+    // Use `tokio::io::stdin` for asynchronous standard input handling
+    let stdin = io::stdin();
+    let mut reader = BufReader::new(stdin).lines();
+
+    while let Ok(Some(line)) = reader.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Attempt to send via RCON if enabled
+        #[cfg(feature = "rcon")]
+        if config.rcon.enabled {
+            if let Err(err) = send_rcon_command(&line, &config).await {
+                eprintln!("Failed to send command via RCON: {}", err);
+            }
+        } else {
+            // Handle other cases if RCON is not enabled
+            eprintln!("RCON not enabled; alternative handling for command: {}", line);
+        }
+    }
+}
+
+#[cfg(feature = "rcon")]
+async fn send_rcon_command(command: &str, config: &Config) -> Result<(), Box<dyn std::error::Error>> {
+    let mut rcon = Rcon::connect_config(config).await?;
+    rcon.cmd(command).await?;
+    rcon.close().await;
+    Ok(())
+}

--- a/src/service/stdin.rs
+++ b/src/service/stdin.rs
@@ -2,38 +2,42 @@ use std::sync::Arc;
 use tokio::io::{self, AsyncBufReadExt, BufReader};
 use crate::config::Config;
 use crate::server::Server;
-
-#[cfg(feature = "rcon")]
-use crate::mc::rcon::Rcon;
+use crate::service::signal::shutdown;
 
 /// Service to read terminal input and send it to the server via RCON or signal handling.
-pub async fn service(config: Arc<Config>, _server: Arc<Server>) {
+pub async fn service(config: Arc<Config>, server: Arc<Server>) {
     // Use `tokio::io::stdin` for asynchronous standard input handling
     let stdin = io::stdin();
     let mut reader = BufReader::new(stdin).lines();
 
     while let Ok(Some(line)) = reader.next_line().await {
-        if line.trim().is_empty() {
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() {
             continue;
         }
 
-        // Attempt to send via RCON if enabled
-        #[cfg(feature = "rcon")]
-        if config.rcon.enabled {
-            if let Err(err) = send_rcon_command(&line, &config).await {
-                eprintln!("Failed to send command via RCON: {}", err);
-            }
-        } else {
-            // Handle other cases if RCON is not enabled
-            eprintln!("RCON not enabled; alternative handling for command: {}", line);
+        // Check for quit command
+        if trimmed_line.eq_ignore_ascii_case("!quit") || trimmed_line.eq_ignore_ascii_case("!exit") {
+            info!("Received quit command");
+            // Gracefully shutdown
+            shutdown(&config, &server).await;
+            break;
         }
+
+        // If !start command, start the server
+        if trimmed_line.eq_ignore_ascii_case("!start") {
+            info!("Received start command");
+            Server::start(config.clone(), server.clone(), None).await;
+            continue;
+        }
+
+        // If !stop command, stop the server
+        if trimmed_line.eq_ignore_ascii_case("!stop") {
+            info!("Received stop command");
+            server.stop(&config).await;
+            continue;
+        }
+        
     }
 }
 
-#[cfg(feature = "rcon")]
-async fn send_rcon_command(command: &str, config: &Config) -> Result<(), Box<dyn std::error::Error>> {
-    let mut rcon = Rcon::connect_config(config).await?;
-    rcon.cmd(command).await?;
-    rcon.close().await;
-    Ok(())
-}


### PR DESCRIPTION
I returned to personally investigate the issue I initially reported (#72 ). Since I'm not primarily a Rust developer, this journey wasn’t straightforward, but I did my best to incorporate stdin handling into the existing code.

Additionally, I conducted testing with a local Minecraft server, and so far, I haven’t encountered any significant issues or crashes.

I hope this change may be beneficial for others as well.