### PR TITLE
Small Typo in Docs

### DIFF
--- a/docs/command_bash.md
+++ b/docs/command_bash.md
@@ -1,1 +1,0 @@
-command-bash.md

--- a/docs/extras.md
+++ b/docs/extras.md
@@ -19,7 +19,7 @@ of new releases.
 
 ## Tips
 
-- [bash with start command](./command_bash.md):
+- [bash with start command](./command-bash.md):
   _how to properly use a bash script as server start command_
 
 ## Experimental features


### PR DESCRIPTION
I clicked on a link in the extras.md file which pointed to a symlink. However, github doesn't evaluate that symlink online, so I deleted the symlink and renamed the reference to the file. A 1 character pull request (plus the deleted symlink). 

Thanks for considering.