### PR TITLE
Fix MOTD/favicon status detection failing to decode component-shaped descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 [[package]]
 name = "minecraft-protocol"
 version = "0.1.0"
-source = "git+https://github.com/timvisee/rust-minecraft-protocol?rev=4f93bb3#4f93bb3438d25fd23410d7c30964971e59cfb327"
+source = "git+https://github.com/mliem2k/rust-minecraft-protocol?rev=359fb4a#359fb4aae556a868c48e20662997a876d4c9da41"
 dependencies = [
  "byteorder",
  "minecraft-protocol-derive",
@@ -784,7 +784,7 @@ dependencies = [
 [[package]]
 name = "minecraft-protocol-derive"
 version = "0.0.0"
-source = "git+https://github.com/timvisee/rust-minecraft-protocol?rev=4f93bb3#4f93bb3438d25fd23410d7c30964971e59cfb327"
+source = "git+https://github.com/mliem2k/rust-minecraft-protocol?rev=359fb4a#359fb4aae556a868c48e20662997a876d4c9da41"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ dotenv = "0.15"
 flate2 = { version = "1.0", default-features = false, features = ["default"] }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 log = "0.4"
-minecraft-protocol = { git = "https://github.com/timvisee/rust-minecraft-protocol", rev = "4f93bb3" }
+minecraft-protocol = { git = "https://github.com/mliem2k/rust-minecraft-protocol", rev = "359fb4a" }
 named-binary-tag = "0.6"
 nix = { version = "0.28", features = ["process", "signal"] }
 notify = "4.0"

--- a/src/status.rs
+++ b/src/status.rs
@@ -6,7 +6,7 @@ use minecraft_protocol::decoder::Decoder;
 use minecraft_protocol::encoder::Encoder;
 use minecraft_protocol::version::v1_14_4::handshake::Handshake;
 use minecraft_protocol::version::v1_14_4::login::LoginStart;
-use minecraft_protocol::version::v1_20_3::status::{ServerStatus, StatusResponse};
+use minecraft_protocol::version::v1_20_3::status::{Description, ServerStatus, StatusResponse};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
@@ -231,11 +231,12 @@ async fn server_status(client_info: &ClientInfo, config: &Config, server: &Serve
         if config.motd.from_server && status.is_some() {
             status.as_ref().unwrap().description.clone()
         } else {
-            match server_state {
+            let motd = match server_state {
                 server::State::Stopped | server::State::Started => config.motd.sleeping.clone(),
                 server::State::Starting => config.motd.starting.clone(),
                 server::State::Stopping => config.motd.stopping.clone(),
-            }
+            };
+            Description::Text(motd)
         }
     };
 


### PR DESCRIPTION
## Summary
Points minecraft-protocol at a fork commit (timvisee/rust-minecraft-protocol#2, pending review) that fixes ServerStatus.description rejecting component-shaped JSON. Any MOTD with color codes, multiple lines, or a server-icon.png favicon in the backend triggers this on most real server implementations, and made lazymc loop forever failing to ever detect the backend as started.

**This PR currently pins to my personal fork of rust-minecraft-protocol, not to timvisee/rust-minecraft-protocol.** Please don't merge with the fork pin in place; once #2 there merges, I'll repoint Cargo.toml's rev at the resulting timvisee/rust-minecraft-protocol commit and update this PR.

Also wraps the configured sleeping/starting/stopping MOTD strings in the new Description type to match.

This is a standalone fix, split out from a previously-bundled PR. It's independent of the decode-error logging improvement (separate PR).

## Fixes
Fixes #66, #88, #102

## Test plan
- cargo check (default, --no-default-features, --features rcon, --features lobby): all pass
- cargo test --locked: passes
- Live smoke test against a real Paper 1.20.4 server with the exact colorful MOTD from #66 (`§b§lLoss Server\n§bIt's dead, just like me`): confirmed lazymc transitions from Stopped to Started and logs "Server is now online" (previously looped forever on "Fetching status").
- Raw protocol probe: a real Minecraft status ping sent through lazymc's public port returns the colorful MOTD correctly rendered as a chat component, confirming the fix works end-to-end for a connecting client, not just internal detection.