### PR TITLE
Log discarded status and handshake decode errors

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -183,7 +183,9 @@ async fn wait_for_status(client: &Client, stream: &mut TcpStream) -> Result<Serv
 
         // Catch status response
         if packet.id == packets::status::CLIENT_STATUS {
-            let status = StatusResponse::decode(&mut packet.data.as_slice()).map_err(|_| ())?;
+            let status = StatusResponse::decode(&mut packet.data.as_slice()).map_err(|err| {
+                debug!(target: "lazymc", "Failed to decode status response from backend server, ignoring: {:?}", err);
+            })?;
             return Ok(status.server_status);
         }
     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -184,7 +184,7 @@ async fn wait_for_status(client: &Client, stream: &mut TcpStream) -> Result<Serv
         // Catch status response
         if packet.id == packets::status::CLIENT_STATUS {
             let status = StatusResponse::decode(&mut packet.data.as_slice()).map_err(|err| {
-                debug!(target: "lazymc", "Failed to decode status response from backend server, ignoring: {:?}", err);
+                debug!(target: "lazymc", "Failed to decode status response from backend server, ignoring: {err:?}");
             })?;
             return Ok(status.server_status);
         }

--- a/src/status.rs
+++ b/src/status.rs
@@ -71,7 +71,7 @@ pub async fn serve(
             let handshake = match Handshake::decode(&mut packet.data.as_slice()) {
                 Ok(handshake) => handshake,
                 Err(err) => {
-                    debug!(target: "lazymc", "Got malformed handshake from client, disconnecting: {:?}", err);
+                    debug!(target: "lazymc", "Got malformed handshake from client, disconnecting: {err:?}");
                     break;
                 }
             };

--- a/src/status.rs
+++ b/src/status.rs
@@ -70,8 +70,8 @@ pub async fn serve(
             // Parse handshake
             let handshake = match Handshake::decode(&mut packet.data.as_slice()) {
                 Ok(handshake) => handshake,
-                Err(_) => {
-                    debug!(target: "lazymc", "Got malformed handshake from client, disconnecting");
+                Err(err) => {
+                    debug!(target: "lazymc", "Got malformed handshake from client, disconnecting: {:?}", err);
                     break;
                 }
             };


### PR DESCRIPTION
## Summary
Both `.map_err(|_| ())` call sites (backend status decode in monitor.rs, client handshake decode in status.rs) converted decode failures into a bare `()`, so trace and debug logs never showed why a backend status probe or client handshake was rejected. Logs the actual DecodeError before discarding it, so future protocol mismatches are diagnosable from lazymc's own logs instead of failing silently.

This is a standalone diagnostics improvement, independent of any other fix, and doesn't require any dependency changes (builds against pure upstream minecraft-protocol).

Directly requested in #102: "It would help if lazymc logged the actual decode error."

## Test plan
- cargo check (default, --no-default-features, --features rcon, --features lobby): all pass
- cargo test --locked: passes